### PR TITLE
NativeMethods: Use safe handles instead of IntPtr

### DIFF
--- a/src/XGBoostSharp/XGBoostSharp.csproj
+++ b/src/XGBoostSharp/XGBoostSharp.csproj
@@ -5,6 +5,7 @@
     <PackageId>XGBoostSharp</PackageId>
     <Description>.Net wrapper for the XGBoost.</Description>
     <PackageTags>xgboost machine-learning classification regression machine learning</PackageTags>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/XGBoostSharp/lib/Booster.cs
+++ b/src/XGBoostSharp/lib/Booster.cs
@@ -74,19 +74,19 @@ public class Booster : IDisposable
         return GetPredictionsArray(predsHandle, predsLen);
     }
 
-    public static float[] GetPredictionsArray(SafeBufferHandle predsHandle, ulong predsLen)
+    public unsafe static float[] GetPredictionsArray(
+        SafeBufferHandle predsHandle, ulong predsLen)
     {
         var length = unchecked((int)predsLen);
         var preds = new float[length];
+        var ptr = (byte*)predsHandle.DangerousGetHandle();
+
         for (var i = 0; i < length; i++)
         {
-            var floatBytes = new byte[4];
-            for (var b = 0; b < 4; b++)
-            {
-                floatBytes[b] = Marshal.ReadByte(predsHandle.DangerousGetHandle(), 4 * i + b);
-            }
-            preds[i] = BitConverter.ToSingle(floatBytes, 0);
+            var span = new ReadOnlySpan<byte>(ptr + 4 * i, 4);
+            preds[i] = MemoryMarshal.Read<float>(span);
         }
+
         return preds;
     }
 

--- a/src/XGBoostSharp/lib/Booster.cs
+++ b/src/XGBoostSharp/lib/Booster.cs
@@ -52,14 +52,12 @@ public class Booster : IDisposable
 
     public byte[] SaveRaw(string rawFormat = ModelFormat.Ubj)
     {
-        ulong outLen;
-        IntPtr outDptr;
         var config = JsonSerializer.SerializeToUtf8Bytes(new { format = rawFormat });
-        ThrowIfError(NativeMethods.XGBoosterSaveModelToBuffer(Handle, config, out outLen, out outDptr));
+        ThrowIfError(NativeMethods.XGBoosterSaveModelToBuffer(Handle, config,
+            out ulong outLen, out var outDptr));
 
-        var length = unchecked((int)outLen);
-        var buffer = new byte[length];
-        Marshal.Copy(outDptr, buffer, 0, length);
+        var buffer = new byte[outLen];
+        Marshal.Copy(outDptr.DangerousGetHandle(), buffer, 0, (int)outLen);
 
         return buffer;
     }

--- a/src/XGBoostSharp/lib/Booster.cs
+++ b/src/XGBoostSharp/lib/Booster.cs
@@ -17,7 +17,7 @@ public class Booster : IDisposable
 
     public Booster(IDictionary<string, object> parameters, DMatrix train)
     {
-        var dmats = new[] { train.Handle };
+        var dmats = new[] { train.DangerousHandle };
         var length = unchecked((ulong)dmats.Length);
         ThrowIfError(NativeMethods.XGBoosterCreate(dmats, length, out var handle));
         m_safeBoosterHandle = handle;
@@ -27,7 +27,7 @@ public class Booster : IDisposable
 
     public Booster(DMatrix train)
     {
-        var dmats = new[] { train.Handle };
+        var dmats = new[] { train.DangerousHandle };
         var length = unchecked((ulong)dmats.Length);
         ThrowIfError(NativeMethods.XGBoosterCreate(dmats, length, out var handle));
         m_safeBoosterHandle = handle;
@@ -45,8 +45,8 @@ public class Booster : IDisposable
         using var handle = new SafeBufferHandle(bytes.Length);
         Marshal.Copy(bytes, 0, handle.DangerousGetHandle(), bytes.Length);
         ThrowIfError(NativeMethods.XGBoosterCreate(null, 0, out var boosterHandle));
-        ThrowIfError(NativeMethods.XGBoosterLoadModelFromBuffer(boosterHandle.DangerousGetHandle(),
-            handle.DangerousGetHandle(), bytes.Length));
+        ThrowIfError(NativeMethods.XGBoosterLoadModelFromBuffer(boosterHandle,
+            handle, bytes.Length));
         m_safeBoosterHandle = boosterHandle;
     }
 

--- a/src/XGBoostSharp/lib/Booster.cs
+++ b/src/XGBoostSharp/lib/Booster.cs
@@ -68,15 +68,13 @@ public class Booster : IDisposable
 
     public float[] Predict(DMatrix test)
     {
-        ulong predsLen;
-        IntPtr predsPtr;
         ThrowIfError(NativeMethods.XGBoosterPredict(
             Handle, test.Handle, NormalPrediction,
-                ntreeLimit: 0, training: 0, out predsLen, out predsPtr));
-        return GetPredictionsArray(predsPtr, predsLen);
+            ntreeLimit: 0, training: 0, out var predsLen, out var predsHandle));
+        return GetPredictionsArray(predsHandle, predsLen);
     }
 
-    public static float[] GetPredictionsArray(IntPtr predsPtr, ulong predsLen)
+    public static float[] GetPredictionsArray(SafeBufferHandle predsHandle, ulong predsLen)
     {
         var length = unchecked((int)predsLen);
         var preds = new float[length];
@@ -85,7 +83,7 @@ public class Booster : IDisposable
             var floatBytes = new byte[4];
             for (var b = 0; b < 4; b++)
             {
-                floatBytes[b] = Marshal.ReadByte(predsPtr, 4 * i + b);
+                floatBytes[b] = Marshal.ReadByte(predsHandle.DangerousGetHandle(), 4 * i + b);
             }
             preds[i] = BitConverter.ToSingle(floatBytes, 0);
         }

--- a/src/XGBoostSharp/lib/Booster.cs
+++ b/src/XGBoostSharp/lib/Booster.cs
@@ -141,11 +141,9 @@ public class Booster : IDisposable
 
     public string[] DumpModelEx(string fmap, int with_stats)
     {
-        int length;
-        IntPtr treePtr;
         var intptrSize = IntPtr.Size;
         ThrowIfError(NativeMethods.XGBoosterDumpModel(Handle,
-            fmap, with_stats, out length, out treePtr));
+            fmap, with_stats, out var length, out var treePtr));
         var trees = new string[length];
         var handle2 = GCHandle.Alloc(treePtr, GCHandleType.Pinned);
 

--- a/src/XGBoostSharp/lib/Booster.cs
+++ b/src/XGBoostSharp/lib/Booster.cs
@@ -13,14 +13,14 @@ public class Booster : IDisposable
     const int NormalPrediction = 0;  // optionMask value for XGBoosterPredict
     int m_numClass = 1;
 
-    public IntPtr Handle => m_safeBoosterHandle.DangerousGetHandle();
+    public SafeBoosterHandle Handle => m_safeBoosterHandle;
 
     public Booster(IDictionary<string, object> parameters, DMatrix train)
     {
         var dmats = new[] { train.Handle };
         var length = unchecked((ulong)dmats.Length);
         ThrowIfError(NativeMethods.XGBoosterCreate(dmats, length, out var handle));
-        m_safeBoosterHandle = new SafeBoosterHandle(handle);
+        m_safeBoosterHandle = handle;
 
         SetParameters(parameters);
     }
@@ -30,14 +30,14 @@ public class Booster : IDisposable
         var dmats = new[] { train.Handle };
         var length = unchecked((ulong)dmats.Length);
         ThrowIfError(NativeMethods.XGBoosterCreate(dmats, length, out var handle));
-        m_safeBoosterHandle = new SafeBoosterHandle(handle);
+        m_safeBoosterHandle = handle;
     }
 
     public Booster(string fileName)
     {
         ThrowIfError(NativeMethods.XGBoosterCreate(null, 0, out var handle));
         ThrowIfError(NativeMethods.XGBoosterLoadModel(handle, fileName));
-        m_safeBoosterHandle = new SafeBoosterHandle(handle);
+        m_safeBoosterHandle = handle;
     }
 
     public Booster(byte[] bytes)
@@ -45,9 +45,9 @@ public class Booster : IDisposable
         using var handle = new SafeBufferHandle(bytes.Length);
         Marshal.Copy(bytes, 0, handle.DangerousGetHandle(), bytes.Length);
         ThrowIfError(NativeMethods.XGBoosterCreate(null, 0, out var boosterHandle));
-        ThrowIfError(NativeMethods.XGBoosterLoadModelFromBuffer(boosterHandle,
+        ThrowIfError(NativeMethods.XGBoosterLoadModelFromBuffer(boosterHandle.DangerousGetHandle(),
             handle.DangerousGetHandle(), bytes.Length));
-        m_safeBoosterHandle = new SafeBoosterHandle(boosterHandle);
+        m_safeBoosterHandle = boosterHandle;
     }
 
     public byte[] SaveRaw(string rawFormat = ModelFormat.Ubj)

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -10,6 +10,7 @@ public class DMatrix : IDisposable
     readonly float m_missing = -1.0F; // arbitrary value used to represent a missing value
 
     public SafeDMatrixHandle Handle => m_safeDMatrixHandle;
+    public IntPtr DangerousHandle => m_safeDMatrixHandle.DangerousGetHandle();
 
     public float[] Label
     {

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -9,7 +9,7 @@ public class DMatrix : IDisposable
     readonly SafeDMatrixHandle m_safeDMatrixHandle;
     readonly float m_missing = -1.0F; // arbitrary value used to represent a missing value
 
-    public IntPtr Handle => m_safeDMatrixHandle.DangerousGetHandle();
+    public SafeDMatrixHandle Handle => m_safeDMatrixHandle;
 
     public float[] Label
     {

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -63,7 +63,8 @@ public class DMatrix : IDisposable
     void SetFloatInfo(string field, float[] floatInfo)
     {
         var length = (ulong)floatInfo.Length;
-        var output = NativeMethods.XGDMatrixSetFloatInfo(Handle, field, floatInfo, length);
+        var output = NativeMethods.XGDMatrixSetFloatInfo(
+            m_safeDMatrixHandle, field, floatInfo, length);
         ThrowIfError(output);
     }
 

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -25,10 +25,9 @@ public class DMatrix : IDisposable
     public DMatrix(float[] data1D, ulong nrows, ulong ncols, float[] labels = null)
     {
         var output = NativeMethods.XGDMatrixCreateFromMat(
-            data1D, nrows, ncols, m_missing, out var handle);
+            data1D, nrows, ncols, m_missing, out m_safeDMatrixHandle);
 
         ThrowIfError(output);
-        m_safeDMatrixHandle = new SafeDMatrixHandle(handle);
 
         if (labels != null)
         {

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -40,22 +40,22 @@ public class DMatrix : IDisposable
 
     float[] GetFloatInfo(string field)
     {
-        ulong lengthULong;
-        IntPtr result;
-        var output = NativeMethods.XGDMatrixGetFloatInfo(Handle,
-            field, out lengthULong, out result);
+        var output = NativeMethods.XGDMatrixGetFloatInfo(m_safeDMatrixHandle, field,
+            out var lengthULong, out var result);
 
         ThrowIfError(output);
 
         var length = unchecked((int)lengthULong);
         var floatInfo = new float[length];
         var floatBytes = new byte[length * 4];
-        Marshal.Copy(result, floatBytes, 0, floatBytes.Length);
+        Marshal.Copy(result.DangerousGetHandle(), floatBytes, 0, floatBytes.Length);
 
         for (var i = 0; i < length; i++)
         {
             floatInfo[i] = BitConverter.ToSingle(floatBytes, i * 4);
         }
+
+        result.Dispose(); // Ensure the SafeBufferHandle is disposed properly
 
         return floatInfo;
     }

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -48,34 +48,36 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterCreate(
-        IntPtr[] dmats,
-        ulong len, out IntPtr handle);
+        SafeDMatrixHandle[] dmats,
+        ulong len, out SafeBoosterHandle handle);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterFree(IntPtr handle);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterSetParam(
-        IntPtr handle, string name, string val);
+        SafeBoosterHandle handle, string name, string val);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterUpdateOneIter(
-        IntPtr bHandle, int iter, IntPtr dHandle);
+        SafeBoosterHandle bHandle, int iter,
+        SafeDMatrixHandle dHandle);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterPredict(
-        IntPtr bHandle, IntPtr dHandle,
+        SafeBoosterHandle bHandle,
+        SafeDMatrixHandle dHandle,
         int optionMask, int ntreeLimit,
         int training, // Only relevant for DART training. See https://github.com/dmlc/xgboost/issues/5601.
         out ulong predsLen, out IntPtr predsPtr);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterSaveModel(
-        IntPtr bHandle, string fileName);
+        SafeBoosterHandle bHandle, string fileName);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterLoadModel(
-        IntPtr bHandle, string fileName);
+        SafeBoosterHandle bHandle, string fileName);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterLoadModelFromBuffer(
@@ -83,7 +85,7 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterSaveModelToBuffer(
-        IntPtr bHandle, byte[] jsonConfig, out ulong outLen,
+        SafeBoosterHandle bHandle, byte[] jsonConfig, out ulong outLen,
         out SafeBufferHandle outDptr);
 
     [DllImport(XGBoostNtvDllName)]
@@ -93,7 +95,7 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterDumpModel(
-        IntPtr handle, string fmap,
+        SafeBoosterHandle handle, string fmap,
         int with_stats, out int out_len,
         out IntPtr dumpStr);
 }

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -99,5 +99,5 @@ public static class NativeMethods
     public static extern int XGBoosterDumpModel(
         SafeBoosterHandle handle, string fmap,
         int with_stats, out int out_len,
-        out IntPtr dumpStr);
+        out SafeBufferHandle dumpStr);
 }

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -48,7 +48,7 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterCreate(
-        SafeDMatrixHandle[] dmats,
+        IntPtr[] dmats,
         ulong len, out SafeBoosterHandle handle);
 
     [DllImport(XGBoostNtvDllName)]
@@ -81,7 +81,8 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterLoadModelFromBuffer(
-        IntPtr bHandle, IntPtr buffer, int length);
+        SafeBoosterHandle bHandle, SafeBufferHandle buffer,
+        int length);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterSaveModelToBuffer(

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -88,7 +88,8 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixCreateFromFile(
-        string fname, int silent, out IntPtr DMtrxHandle);
+        string fname, int silent,
+        out SafeDMatrixHandle DMtrxHandle);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterDumpModel(

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -43,7 +43,7 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixSetFloatInfo(
-        IntPtr handle, string field,
+        SafeDMatrixHandle handle, string field,
         float[] array, ulong len);
 
     [DllImport(XGBoostNtvDllName)]

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -48,8 +48,9 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterCreate(
-        IntPtr[] dmats,
-        ulong len, out SafeBoosterHandle handle);
+        // array of safehandles is not supported, stick with IntPtr.
+        IntPtr[] dmats, ulong len,
+        out SafeBoosterHandle handle);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterFree(IntPtr handle);

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -69,7 +69,8 @@ public static class NativeMethods
         SafeDMatrixHandle dHandle,
         int optionMask, int ntreeLimit,
         int training, // Only relevant for DART training. See https://github.com/dmlc/xgboost/issues/5601.
-        out ulong predsLen, out IntPtr predsPtr);
+        out ulong predsLen,
+        out SafeBufferHandle predsPtr);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterSaveModel(

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -31,7 +31,7 @@ public static class NativeMethods
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixCreateFromMat(
         float[] data, ulong nrow, ulong ncol,
-        float missing, out IntPtr handle);
+        float missing, out SafeDMatrixHandle handle);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixFree(IntPtr handle);

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -83,7 +83,8 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterSaveModelToBuffer(
-        IntPtr bHandle, byte[] jsonConfig, out ulong outLen, out IntPtr outDptr);
+        IntPtr bHandle, byte[] jsonConfig, out ulong outLen,
+        out SafeBufferHandle outDptr);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixCreateFromFile(

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -38,8 +38,8 @@ public static class NativeMethods
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixGetFloatInfo(
-        IntPtr handle, string field,
-        out ulong len, out IntPtr result);
+        SafeDMatrixHandle handle, string field,
+        out ulong len, out SafeBufferHandle result);
 
     [DllImport(XGBoostNtvDllName)]
     public static extern int XGDMatrixSetFloatInfo(


### PR DESCRIPTION
This PR adds the following:
 - Use SafeHanldes where possible for p/invoke in NativeMethods.
 - Refactor and simplify accordingly.