### PR TITLE
Add feature type and feature name handling

### DIFF
--- a/src/XGBoostSharp.Tests/DMatrixTest.cs
+++ b/src/XGBoostSharp.Tests/DMatrixTest.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using XGBoostSharp.lib;
+
+namespace XGBoostSharp.Test;
+
+[TestClass]
+public class DMatrixTest
+{
+    readonly float[][] m_dataTrain = [[1, 2, 3, 4]];
+    readonly float[] m_labelsTrain = [1];
+
+    [TestMethod]
+    public void DMatrix_SetFeatureNames()
+    {
+        string[] featureNames = ["f1", "f2", "f3", "f4"];
+
+        var sut = new DMatrix(m_dataTrain, m_labelsTrain);
+        sut.SetFeatureNames(featureNames);
+
+        var featureNamesFromDMatrix = sut.GetFeatureNames();
+        TestUtils.AssertAreEqual(featureNames, featureNamesFromDMatrix);
+    }
+
+    [TestMethod]
+    public void DMatrix_SetFeatureTypes()
+    {
+        string[] featureTypes = [FeatureType.Categorical,
+            FeatureType.Float,
+            FeatureType.Integer,
+            FeatureType.Boolean];
+
+        var sut = new DMatrix(m_dataTrain, m_labelsTrain);
+        sut.SetFeatureTypes(featureTypes);
+
+        var featureTypesFromDMatrix = sut.GetFeatureTypes();
+        TestUtils.AssertAreEqual(featureTypes, featureTypesFromDMatrix);
+    }
+}

--- a/src/XGBoostSharp.Tests/XGBClassifierTest.cs
+++ b/src/XGBoostSharp.Tests/XGBClassifierTest.cs
@@ -118,10 +118,10 @@ public class XGBClassifierTest
         var dataTest = TestUtils.DataTest;
 
         using var sut = CreateSut();
-        var dMatrixTrain = new DMatrix(dataTrain, labelsTrain);
+        using var dMatrixTrain = new DMatrix(dataTrain, labelsTrain);
         sut.Fit(dMatrixTrain);
 
-        var dMatrixTest = new DMatrix(dataTest);
+        using var dMatrixTest = new DMatrix(dataTest);
         var actual = sut.PredictProbability(dMatrixTest);
         var expected = TestUtils.ExpectedClassifierProbabilityPredictions;
 

--- a/src/XGBoostSharp.Tests/XGBClassifierTest.cs
+++ b/src/XGBoostSharp.Tests/XGBClassifierTest.cs
@@ -111,6 +111,24 @@ public class XGBClassifierTest
     }
 
     [TestMethod]
+    public void XGBClassifierTest_UsingDMatrixDirectly()
+    {
+        var dataTrain = TestUtils.DataTrain;
+        var labelsTrain = TestUtils.LabelsTrain;
+        var dataTest = TestUtils.DataTest;
+
+        using var sut = CreateSut();
+        var dMatrixTrain = new DMatrix(dataTrain, labelsTrain);
+        sut.Fit(dMatrixTrain);
+
+        var dMatrixTest = new DMatrix(dataTest);
+        var actual = sut.PredictProbability(dMatrixTest);
+        var expected = TestUtils.ExpectedClassifierProbabilityPredictions;
+
+        TestUtils.AssertAreEqual(expected, actual);
+    }
+
+    [TestMethod]
     public void XGBClassifierTest_DumpModelEx()
     {
         var dataTrain = TestUtils.DataTrain;

--- a/src/XGBoostSharp.Tests/XGBRegressorTest.cs
+++ b/src/XGBoostSharp.Tests/XGBRegressorTest.cs
@@ -100,10 +100,10 @@ public class XGBRegressorTest
         var dataTest = TestUtils.DataTest;
 
         using var sut = CreateSut();
-        var dMatrixTrain = new DMatrix(dataTrain, labelsTrain);
+        using var dMatrixTrain = new DMatrix(dataTrain, labelsTrain);
         sut.Fit(dMatrixTrain);
 
-        var dMatrixTest = new DMatrix(dataTest);
+        using var dMatrixTest = new DMatrix(dataTest);
         var actual = sut.Predict(dMatrixTest);
         var expected = TestUtils.ExpectedRegressionPredictions;
 

--- a/src/XGBoostSharp.Tests/XGBRegressorTest.cs
+++ b/src/XGBoostSharp.Tests/XGBRegressorTest.cs
@@ -93,6 +93,24 @@ public class XGBRegressorTest
     }
 
     [TestMethod]
+    public void XGBRegressorTest_UsingDMatrixDirectly()
+    {
+        var dataTrain = TestUtils.DataTrain;
+        var labelsTrain = TestUtils.LabelsTrain;
+        var dataTest = TestUtils.DataTest;
+
+        using var sut = CreateSut();
+        var dMatrixTrain = new DMatrix(dataTrain, labelsTrain);
+        sut.Fit(dMatrixTrain);
+
+        var dMatrixTest = new DMatrix(dataTest);
+        var actual = sut.Predict(dMatrixTest);
+        var expected = TestUtils.ExpectedRegressionPredictions;
+
+        TestUtils.AssertAreEqual(expected, actual);
+    }
+
+    [TestMethod]
     public void XGBRegressorTest_DumpModelEx()
     {
         var dataTrain = TestUtils.DataTrain;

--- a/src/XGBoostSharp/XGBClassifier.cs
+++ b/src/XGBoostSharp/XGBClassifier.cs
@@ -161,7 +161,7 @@ public class XGBClassifier : XGBModelBase
     public void Fit(float[][] data, float[] labels)
     {
         using var train = new DMatrix(data, labels);
-        m_booster = Train(m_parameters, train);
+        Fit(train);
     }
 
     /// <summary>
@@ -190,8 +190,7 @@ public class XGBClassifier : XGBModelBase
     public float[] Predict(float[][] data)
     {
         using var dMatrix = new DMatrix(data);
-        var predictions = m_booster.Predict(dMatrix).Select(v => v > 0.5f ? 1f : 0f).ToArray();
-        return predictions;
+        return Predict(dMatrix);
     }
 
     /// <summary>
@@ -212,8 +211,7 @@ public class XGBClassifier : XGBModelBase
     public float[] PredictRaw(float[][] data)
     {
         using var dMatrix = new DMatrix(data);
-        var predictions = m_booster.Predict(dMatrix);
-        return predictions;
+        return PredictRaw(dMatrix);
     }
 
     public float[] PredictRaw(DMatrix dMatrix)

--- a/src/XGBoostSharp/XGBClassifier.cs
+++ b/src/XGBoostSharp/XGBClassifier.cs
@@ -164,6 +164,17 @@ public class XGBClassifier : XGBModelBase
         m_booster = Train(m_parameters, train);
     }
 
+    /// <summary>
+    ///   Fit the gradient boosting model
+    /// </summary>
+    /// <param name="matrix">
+    ///   DMatrix
+    /// </param>
+    public void Fit(DMatrix matrix)
+    {
+        m_booster = Train(m_parameters, matrix);
+    }
+
     public void SetParameter(string parameterName, object parameterValue) =>
         m_parameters[parameterName] = parameterValue;
 
@@ -171,7 +182,7 @@ public class XGBClassifier : XGBModelBase
     ///   Predict using the gradient boosted model
     /// </summary>
     /// <param name="data">
-    ///   Feature matrix to do predicitons on
+    ///   Feature matrix to do predictions on
     /// </param>
     /// <returns>
     ///   Predictions
@@ -183,17 +194,38 @@ public class XGBClassifier : XGBModelBase
         return predictions;
     }
 
+    /// <summary>
+    ///   Predict using the gradient boosted model
+    /// </summary>
+    /// <param name="dMatrix">
+    ///   DMatrix to do predictions on
+    /// </param>
+    /// <returns>
+    ///   Predictions
+    /// </returns>
+    public float[] Predict(DMatrix dMatrix)
+    {
+        var predictions = m_booster.Predict(dMatrix).Select(v => v > 0.5f ? 1f : 0f).ToArray();
+        return predictions;
+    }
+
     public float[] PredictRaw(float[][] data)
     {
         using var dMatrix = new DMatrix(data);
         var predictions = m_booster.Predict(dMatrix);
         return predictions;
     }
+
+    public float[] PredictRaw(DMatrix dMatrix)
+    {
+        return m_booster.Predict(dMatrix);
+    }
+
     /// <summary>
     ///   Predict using the gradient boosted model
     /// </summary>
     /// <param name="data">
-    ///   Feature matrix to do predicitons on
+    ///   Feature matrix to do predictions on
     /// </param>
     /// <returns>
     ///   The probabilities for each classification being the actual
@@ -202,6 +234,21 @@ public class XGBClassifier : XGBModelBase
     public float[][] PredictProbability(float[][] data)
     {
         using var dMatrix = new DMatrix(data);
+        return PredictProbability(dMatrix);
+    }
+
+    /// <summary>
+    ///   Predict using the gradient boosted model
+    /// </summary>
+    /// <param name="dMatrix">
+    ///   DMatrix to do predictions on
+    /// </param>
+    /// <returns>
+    ///   The probabilities for each classification being the actual
+    ///   classification for each row
+    /// </returns>
+    public float[][] PredictProbability(DMatrix dMatrix)
+    {
         var predictions = m_booster.Predict(dMatrix);
         var classCount = (int)m_parameters[ParameterNames.num_class];
         var observationCount = predictions.Length / classCount;

--- a/src/XGBoostSharp/XGBRegressor.cs
+++ b/src/XGBoostSharp/XGBRegressor.cs
@@ -158,6 +158,17 @@ public class XGBRegressor : XGBModelBase
         m_booster = Train(m_parameters, train);
     }
 
+    /// <summary>
+    ///   Fit the gradient boosting model
+    /// </summary>
+    /// <param name="dMatrix">
+    ///   DMatrix
+    /// </param>
+    public void Fit(DMatrix dMatrix)
+    {
+        m_booster = Train(m_parameters, dMatrix);
+    }
+
     public void SetParameter(string parameterName, object parameterValue) =>
         m_parameters[parameterName] = parameterValue;
 
@@ -165,7 +176,7 @@ public class XGBRegressor : XGBModelBase
     ///   Predict using the gradient boosted model
     /// </summary>
     /// <param name="data">
-    ///   Feature matrix to do predicitons on
+    ///   Feature matrix to do predictions on
     /// </param>
     /// <returns>
     ///   Predictions
@@ -175,4 +186,15 @@ public class XGBRegressor : XGBModelBase
         using var test = new DMatrix(data);
         return m_booster.Predict(test);
     }
+
+    /// <summary>
+    ///   Predict using the gradient boosted model
+    /// </summary>
+    /// <param name="dMatrix">
+    ///   DMatrix to do predictions on
+    /// </param>
+    /// <returns>
+    ///   Predictions
+    /// </returns>
+    public float[] Predict(DMatrix dMatrix) => m_booster.Predict(dMatrix);
 }

--- a/src/XGBoostSharp/XGBRegressor.cs
+++ b/src/XGBoostSharp/XGBRegressor.cs
@@ -155,7 +155,7 @@ public class XGBRegressor : XGBModelBase
     public void Fit(float[][] data, float[] labels)
     {
         using var train = new DMatrix(data, labels);
-        m_booster = Train(m_parameters, train);
+        Fit(train);
     }
 
     /// <summary>
@@ -184,7 +184,7 @@ public class XGBRegressor : XGBModelBase
     public float[] Predict(float[][] data)
     {
         using var test = new DMatrix(data);
-        return m_booster.Predict(test);
+        return Predict(test);
     }
 
     /// <summary>

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -68,6 +68,51 @@ public class DMatrix : IDisposable
         ThrowIfError(output);
     }
 
+    public void SetFeatureNames(string[] featureNames)
+    {
+        SetFeatureInfo(featureNames, "feature_name");
+    }
+
+    public string[] GetFeatureNames()
+    {
+        return GetFeatureInfo("feature_name");
+    }
+
+    public void SetFeatureTypes(string[] featureTypes)
+    {
+        SetFeatureInfo(featureTypes, "feature_type");
+    }
+
+    public string[] GetFeatureTypes()
+    {
+        return GetFeatureInfo("feature_type");
+    }
+
+    void SetFeatureInfo(string[] featureInfo, string field)
+    {
+        var length = (ulong)featureInfo.Length;
+        var output = NativeMethods.XGDMatrixSetStrFeatureInfo(Handle, field, featureInfo, length);
+        ThrowIfError(output);
+    }
+
+    string[] GetFeatureInfo(string field)
+    {
+        ulong lengthULong;
+        IntPtr result;
+        var output = NativeMethods.XGDMatrixGetStrFeatureInfo(Handle, field, out lengthULong, out result);
+        ThrowIfError(output);
+
+        var length = unchecked((int)lengthULong);
+        var featureInfo = new string[length];
+        for (var i = 0; i < length; i++)
+        {
+            IntPtr strPtr = Marshal.ReadIntPtr(result, i * IntPtr.Size);
+            featureInfo[i] = Marshal.PtrToStringAnsi(strPtr);
+        }
+
+        return featureInfo;
+    }
+
     static void ThrowIfError(int output)
     {
         if (output == -1)

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -13,8 +13,8 @@ public class DMatrix : IDisposable
 
     public float[] Label
     {
-        get { return GetFloatInfo("label"); }
-        set { SetFloatInfo("label", value); }
+        get { return GetFloatInfo(Fields.label); }
+        set { SetFloatInfo(Fields.label, value); }
     }
 
     public DMatrix(float[][] data, float[] labels = null)

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -68,38 +68,26 @@ public class DMatrix : IDisposable
         ThrowIfError(output);
     }
 
-    public void SetFeatureNames(string[] featureNames)
-    {
-        SetFeatureInfo(featureNames, "feature_name");
-    }
+    public void SetFeatureNames(string[] featureNames) => SetFeatureInfo(featureNames, Fields.feature_name);
 
-    public string[] GetFeatureNames()
-    {
-        return GetFeatureInfo("feature_name");
-    }
+    public string[] GetFeatureNames() => GetFeatureInfo(Fields.feature_name);
 
-    public void SetFeatureTypes(string[] featureTypes)
-    {
-        SetFeatureInfo(featureTypes, "feature_type");
-    }
+    public void SetFeatureTypes(string[] featureTypes) => SetFeatureInfo(featureTypes, Fields.feature_type);
 
-    public string[] GetFeatureTypes()
-    {
-        return GetFeatureInfo("feature_type");
-    }
+    public string[] GetFeatureTypes() => GetFeatureInfo(Fields.feature_type);
 
     void SetFeatureInfo(string[] featureInfo, string field)
     {
         var length = (ulong)featureInfo.Length;
-        var output = NativeMethods.XGDMatrixSetStrFeatureInfo(Handle, field, featureInfo, length);
+        var output = NativeMethods.XGDMatrixSetStrFeatureInfo(
+            Handle, field, featureInfo, length);
         ThrowIfError(output);
     }
 
     string[] GetFeatureInfo(string field)
     {
-        ulong lengthULong;
-        IntPtr result;
-        var output = NativeMethods.XGDMatrixGetStrFeatureInfo(Handle, field, out lengthULong, out result);
+        var output = NativeMethods.XGDMatrixGetStrFeatureInfo(
+            Handle, field, out var lengthULong, out var result);
         ThrowIfError(output);
 
         var length = unchecked((int)lengthULong);

--- a/src/XGBoostSharp/lib/FeatureType.cs
+++ b/src/XGBoostSharp/lib/FeatureType.cs
@@ -1,0 +1,9 @@
+﻿namespace XGBoostSharp.lib;
+
+public static class FeatureType
+{
+    public const string Categorical = "c";
+    public const string Float = "q";
+    public const string Integer = "int";
+    public const string Boolean = "i";
+}

--- a/src/XGBoostSharp/lib/Fields.cs
+++ b/src/XGBoostSharp/lib/Fields.cs
@@ -1,0 +1,10 @@
+﻿namespace XGBoostSharp.lib;
+
+public static class Fields
+{
+#pragma warning disable IDE1006 // Naming Styles
+    public const string label = nameof(label);
+    public const string feature_name = nameof(feature_name);
+    public const string feature_type = nameof(feature_type);
+#pragma warning restore IDE1006 // Naming Styles
+}

--- a/src/XGBoostSharp/lib/NativeMethods.cs
+++ b/src/XGBoostSharp/lib/NativeMethods.cs
@@ -47,6 +47,16 @@ public static class NativeMethods
         float[] array, ulong len);
 
     [DllImport(XGBoostNtvDllName)]
+    public static extern int XGDMatrixSetStrFeatureInfo(
+        IntPtr handle, string field,
+        string[] values, ulong len);
+
+    [DllImport(XGBoostNtvDllName)]
+    public static extern int XGDMatrixGetStrFeatureInfo(
+        IntPtr handle, string field,
+        out ulong len, out IntPtr result);
+
+    [DllImport(XGBoostNtvDllName)]
     public static extern int XGBoosterCreate(
         IntPtr[] dmats,
         ulong len, out IntPtr handle);


### PR DESCRIPTION
Right now, the DMatrix is internal to the booster, but it might make sense to simply let people pass a DMatrix directly to the classifier/regressor?