### PR TITLE
Improve Missing Value / `null` Handling

### DIFF
--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -22,10 +22,10 @@ public class DMatrix : IDisposable
     /// </summary>
     /// <param name="data">The 2D array containing the feature data.</param>
     /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
-    /// <param name="m_missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
+    /// <param name="missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
     /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
-    public DMatrix(float[][] data, float[] labels = null, float m_missing = DefaultMissing)
-        : this(Flatten2DArray(data), unchecked((ulong)data.Length), unchecked((ulong)data[0].Length), labels, m_missing)
+    public DMatrix(float[][] data, float[] labels = null, float missing = DefaultMissing)
+        : this(Flatten2DArray(data), unchecked((ulong)data.Length), unchecked((ulong)data[0].Length), labels, missing)
     {
     }
 
@@ -36,12 +36,12 @@ public class DMatrix : IDisposable
     /// <param name="nrows">Number of rows in the matrix.</param>
     /// <param name="ncols">Number of columns in the matrix.</param>
     /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
-    /// <param name="m_missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
+    /// <param name="missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
     /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
-    public DMatrix(float[] data1D, ulong nrows, ulong ncols, float[] labels = null, float m_missing = DefaultMissing)
+    public DMatrix(float[] data1D, ulong nrows, ulong ncols, float[] labels = null, float missing = DefaultMissing)
     {
         var output = NativeMethods.XGDMatrixCreateFromMat(
-            data1D, nrows, ncols, m_missing, out var handle);
+            data1D, nrows, ncols, missing, out var handle);
 
         ThrowIfError(output);
         m_safeDMatrixHandle = new SafeDMatrixHandle(handle);

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -25,14 +25,9 @@ public class DMatrix : IDisposable
     /// <param name="m_missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
     /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
     public DMatrix(float[][] data, float[] labels = null, float m_missing = DefaultMissing)
-        : this(
-            Flatten2DArray(data),
-            unchecked((ulong)data.Length),
-            unchecked((ulong)data[0].Length),
-            labels,
-            m_missing
-        )
-    { }
+        : this(Flatten2DArray(data), unchecked((ulong)data.Length), unchecked((ulong)data[0].Length), labels, m_missing)
+    {
+    }
 
     /// <summary>
     /// Creates a DMatrix from a 1D array of float values with specified dimensions and optional labels.
@@ -43,13 +38,7 @@ public class DMatrix : IDisposable
     /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
     /// <param name="m_missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
     /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
-    public DMatrix(
-        float[] data1D,
-        ulong nrows,
-        ulong ncols,
-        float[] labels = null,
-        float m_missing = DefaultMissing
-    )
+    public DMatrix(float[] data1D, ulong nrows, ulong ncols, float[] labels = null, float m_missing = DefaultMissing)
     {
         var output = NativeMethods.XGDMatrixCreateFromMat(
             data1D, nrows, ncols, m_missing, out var handle);

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -7,7 +7,7 @@ namespace XGBoostSharp.lib;
 public class DMatrix : IDisposable
 {
     readonly SafeDMatrixHandle m_safeDMatrixHandle;
-    readonly float m_missing = -1.0F; // arbitrary value used to represent a missing value
+    const float DefaultMissing = float.NaN;
 
     public IntPtr Handle => m_safeDMatrixHandle.DangerousGetHandle();
 
@@ -17,15 +17,57 @@ public class DMatrix : IDisposable
         set { SetFloatInfo(Fields.label, value); }
     }
 
-    public DMatrix(float[][] data, float[] labels = null)
-        : this(Flatten2DArray(data), unchecked((ulong)data.Length), unchecked((ulong)data[0].Length), labels)
-    {
-    }
+    /// <summary>
+    /// Null-Permissive constructor to create a DMatrix from a 2D array of float values with optional labels.
+    /// </summary>
+    /// <param name="data">The 2D array containing the feature data.</param>
+    /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
+    /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
+    public DMatrix(float?[][] data, float?[] labels = null)
+        : this(ReplaceNullValues(data, DefaultMissing), ReplaceNullValues(labels, DefaultMissing))
+    { }
 
-    public DMatrix(float[] data1D, ulong nrows, ulong ncols, float[] labels = null)
+    /// <summary>
+    /// Creates a DMatrix from a 2D array of float values with optional labels.
+    /// </summary>
+    /// <param name="data">The 2D array containing the feature data.</param>
+    /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
+    /// <param name="m_missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
+    /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
+    public DMatrix(float[][] data, float[] labels = null, float m_missing = DefaultMissing)
+        : this(
+            Flatten2DArray(data),
+            unchecked((ulong)data.Length),
+            unchecked((ulong)data[0].Length),
+            labels,
+            m_missing
+        )
+    { }
+
+    /// <summary>
+    /// Creates a DMatrix from a 1D array of float values with specified dimensions and optional labels.
+    /// </summary>
+    /// <param name="data1D">The 1D array containing the feature data in row-major order.</param>
+    /// <param name="nrows">Number of rows in the matrix.</param>
+    /// <param name="ncols">Number of columns in the matrix.</param>
+    /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
+    /// <param name="m_missing">Value to be treated as missing in the dataset. Default is float.NaN.</param>
+    /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
+    public DMatrix(
+        float[] data1D,
+        ulong nrows,
+        ulong ncols,
+        float[] labels = null,
+        float m_missing = DefaultMissing
+    )
     {
         var output = NativeMethods.XGDMatrixCreateFromMat(
-            data1D, nrows, ncols, m_missing, out var handle);
+            data1D,
+            nrows,
+            ncols,
+            m_missing,
+            out var handle
+        );
 
         ThrowIfError(output);
         m_safeDMatrixHandle = new SafeDMatrixHandle(handle);
@@ -35,6 +77,12 @@ public class DMatrix : IDisposable
             Label = labels;
         }
     }
+
+    static float[][] ReplaceNullValues(float?[][] data, float m_missing) =>
+        data.Select(r => ReplaceNullValues(r, m_missing)).ToArray();
+
+    static float[] ReplaceNullValues(float?[] labels, float m_missing) =>
+        labels?.Select(val => val ?? m_missing).ToArray();
 
     static float[] Flatten2DArray(float[][] data2D) =>
         data2D.SelectMany(row => row).ToArray();

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -52,12 +52,7 @@ public class DMatrix : IDisposable
     )
     {
         var output = NativeMethods.XGDMatrixCreateFromMat(
-            data1D,
-            nrows,
-            ncols,
-            m_missing,
-            out var handle
-        );
+            data1D, nrows, ncols, m_missing, out var handle);
 
         ThrowIfError(output);
         m_safeDMatrixHandle = new SafeDMatrixHandle(handle);

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -68,12 +68,6 @@ public class DMatrix : IDisposable
         }
     }
 
-    static float[][] ReplaceNullValues(float?[][] data, float m_missing) =>
-        data.Select(r => ReplaceNullValues(r, m_missing)).ToArray();
-
-    static float[] ReplaceNullValues(float?[] labels, float m_missing) =>
-        labels?.Select(val => val ?? m_missing).ToArray();
-
     static float[] Flatten2DArray(float[][] data2D) =>
         data2D.SelectMany(row => row).ToArray();
 

--- a/src/XGBoostSharp/lib/DMatrix.cs
+++ b/src/XGBoostSharp/lib/DMatrix.cs
@@ -18,16 +18,6 @@ public class DMatrix : IDisposable
     }
 
     /// <summary>
-    /// Null-Permissive constructor to create a DMatrix from a 2D array of float values with optional labels.
-    /// </summary>
-    /// <param name="data">The 2D array containing the feature data.</param>
-    /// <param name="labels">Optional array of labels corresponding to the data rows. Default is null.</param>
-    /// <exception cref="DllFailException">Thrown when the native XGBoost library encounters an error during matrix creation.</exception>
-    public DMatrix(float?[][] data, float?[] labels = null)
-        : this(ReplaceNullValues(data, DefaultMissing), ReplaceNullValues(labels, DefaultMissing))
-    { }
-
-    /// <summary>
     /// Creates a DMatrix from a 2D array of float values with optional labels.
     /// </summary>
     /// <param name="data">The 2D array containing the feature data.</param>


### PR DESCRIPTION
XGBoostSharp currently uses `-1.0F` as a constant to represent missing values. This is contrary to the official Python library, which uses `float.NaN`. See, e.g., the parameter missing [here](https://github.com/mdabros/XGBoostSharp/pull/DMatrix). XGBoostSharp currently does not allow its users to change that value.

Changes in this PR:

- Allow users to change the constant that represents a missing value, similar to the Python and C API.
- Change the default missing value constant to float.NaN. While technically this is a breaking change, it can probably be considered a bug fix as well.
- Add a new constructor that automatically handles input and feature arrays containing null values.

Note: I have not yet E2E tested the change and found it hard to set up a meaningful unit test. I wanted to open the PR ASAP, though, to get @mdabros's opinion on this.