### PR TITLE
Update native packages for osx-arm64, osx-x64, and linux-x64

### DIFF
--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -7,8 +7,8 @@
     <description>XGBoostSharp for cpu.</description>
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
-      <dependency id="libxgboost-2.0.3-linux-x64" version="1.0.1" />
-      <dependency id="libxgboost-2.0.3-osx-x64" version="1.0.0" />
+      <dependency id="libxgboost-2.0.3-linux-x64" version="1.0.2" />
+      <dependency id="libxgboost-2.0.3-osx-x64" version="1.0.1" />
       <dependency id="libxgboost-2.0.3-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libxgboost-2.0.3-linux-x64" Version="1.0.1" />
-    <PackageReference Include="libxgboost-2.0.3-osx-x64" Version="1.0.0" />
+    <PackageReference Include="libxgboost-2.0.3-linux-x64" Version="1.0.2" />
+    <PackageReference Include="libxgboost-2.0.3-osx-x64" Version="1.0.1" />
     <PackageReference Include="libxgboost-2.0.3-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="3.8.2" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates the native packages for osx-arm64, osx-x64, and linux-x64. This should resolve the issue described in 
https://github.com/mdabros/XGBoostSharp/issues/45