### PR TITLE
Bump version to 0.5 before new release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4",
+    "version": "0.5",
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Since the upcoming release contains new features, and a breaking change, the minor version is bumped. Moving forward, I will try to be more consistent with this, since previous releases also contained new features without minor bump.