### PR TITLE
Bump libxgboost-2.0.3-linux-x64 to 1.0.3

### DIFF
--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -7,7 +7,7 @@
     <description>XGBoostSharp for cpu.</description>
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
-      <dependency id="libxgboost-2.0.3-linux-x64" version="1.0.2" />
+      <dependency id="libxgboost-2.0.3-linux-x64" version="1.0.3" />
       <dependency id="libxgboost-2.0.3-osx-x64" version="1.0.1" />
       <dependency id="libxgboost-2.0.3-win-x64" version="1.0.0" />
     </dependencies>

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libxgboost-2.0.3-linux-x64" Version="1.0.2" />
+    <PackageReference Include="libxgboost-2.0.3-linux-x64" Version="1.0.3" />
     <PackageReference Include="libxgboost-2.0.3-osx-x64" Version="1.0.1" />
     <PackageReference Include="libxgboost-2.0.3-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="3.8.2" />


### PR DESCRIPTION
This PR bumps the libxgboost-2.0.3-linux-x64 to 1.0.3, and solves the issue mentioned here: https://github.com/mdabros/XGBoostSharp/issues/45#issuecomment-2700705590