### PR TITLE
Bump native libxgboost to 3.2.0, update global.json, and fix osx .targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,15 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
 1. Get the latest version of the managed packages from nuget.org.
    - https://www.nuget.org/packages/XGBoostSharp. Note that this requires a
      reference to one of the native packages (see below).
+     reference to one of the native packages (see below).
    - https://www.nuget.org/packages/XGBoostSharp-cpu: This comes with native
-     packages for cpu for win-x64, linux-x64, osx-x64, and osx-arm64.
+     packages for cpu for win-x64, linux-x64, and osx-x64.
 2. If using the XGBoostSharp package the native packages can be installed
    separately from nuget.org.
    - x64 packages:
      - https://www.nuget.org/packages/libxgboost-3.2.0-win-x64/
      - https://www.nuget.org/packages/libxgboost-3.2.0-linux-x64/
      - https://www.nuget.org/packages/libxgboost-3.2.0-osx-x64/
-   - ARM64 packages:
+   - ARM64 packages (note that these are not part of the XGBoostSharp-cpu
+     package):
      - https://www.nuget.org/packages/libxgboost-3.2.0-osx-arm64/

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
    - https://www.nuget.org/packages/XGBoostSharp. Note that this requires a
      reference to one of the native packages (see below).
    - https://www.nuget.org/packages/XGBoostSharp-cpu: This comes with native
-     packages for cpu for win-x64, linux-x64, and osx-x64.
+     packages for cpu for win-x64, linux-x64, osx-x64, and osx-arm64.
 2. If using the XGBoostSharp package the native packages can be installed
    separately from nuget.org.
    - x64 packages:

--- a/README.md
+++ b/README.md
@@ -51,15 +51,13 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
 1. Get the latest version of the managed packages from nuget.org.
    - https://www.nuget.org/packages/XGBoostSharp. Note that this requires a
      reference to one of the native packages (see below).
-     reference to one of the native packages (see below).
    - https://www.nuget.org/packages/XGBoostSharp-cpu: This comes with native
-     packages for cpu for win-x64, linux-x64, and osx-x64.
+     packages for cpu for win-x64, linux-x64, osx-x64, and osx-arm64.
 2. If using the XGBoostSharp package the native packages can be installed
    separately from nuget.org.
    - x64 packages:
      - https://www.nuget.org/packages/libxgboost-3.2.0-win-x64/
      - https://www.nuget.org/packages/libxgboost-3.2.0-linux-x64/
      - https://www.nuget.org/packages/libxgboost-3.2.0-osx-x64/
-   - ARM64 packages (note that these are not part of the XGBoostSharp-cpu
-     package):
+   - ARM64 packages:
      - https://www.nuget.org/packages/libxgboost-3.2.0-osx-arm64/

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
 2. If using the XGBoostSharp package the native packages can be installed
    separately from nuget.org.
    - x64 packages:
-     - https://www.nuget.org/packages/libxgboost-2.0.3-win-x64/
-     - https://www.nuget.org/packages/libxgboost-2.0.3-linux-x64/
-     - https://www.nuget.org/packages/libxgboost-2.0.3-osx-x64/
+     - https://www.nuget.org/packages/libxgboost-3.2.0-win-x64/
+     - https://www.nuget.org/packages/libxgboost-3.2.0-linux-x64/
+     - https://www.nuget.org/packages/libxgboost-3.2.0-osx-x64/
    - ARM64 packages (note that these are not part of the XGBoostSharp-cpu
      package):
-     - https://www.nuget.org/packages/libxgboost-2.0.3-osx-arm64/
+     - https://www.nuget.org/packages/libxgboost-3.2.0-osx-arm64/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,5 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
      - https://www.nuget.org/packages/libxgboost-3.2.0-win-x64/
      - https://www.nuget.org/packages/libxgboost-3.2.0-linux-x64/
      - https://www.nuget.org/packages/libxgboost-3.2.0-osx-x64/
-   - ARM64 packages (note that these are not part of the XGBoostSharp-cpu
-     package):
+   - ARM64 packages:
      - https://www.nuget.org/packages/libxgboost-3.2.0-osx-arm64/

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
     "sdk": {
         "version": "10.0.100",
         "rollForward": "latestFeature",
-        "allowPrerelease": true
+        "allowPrerelease": false
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "sdk": {
         "version": "10.0.100",
-        "rollForward": "latestFeature",
+        "rollForward": "latestPatch",
         "allowPrerelease": false
     }
 }

--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -8,7 +8,7 @@
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-linux-x64" version="1.0.0" />
-      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.0" />
+      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.1" />
       <dependency id="libxgboost-3.2.0-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>

--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -8,7 +8,8 @@
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-linux-x64" version="1.0.0" />
-      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.2" />
+      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.3" />
+      <dependency id="libxgboost-3.2.0-osx-arm64" version="1.0.3" />
       <dependency id="libxgboost-3.2.0-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>

--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -7,9 +7,9 @@
     <description>XGBoostSharp for cpu.</description>
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
-      <dependency id="libxgboost-2.0.3-linux-x64" version="1.0.3" />
-      <dependency id="libxgboost-2.0.3-osx-x64" version="1.0.1" />
-      <dependency id="libxgboost-2.0.3-win-x64" version="1.0.0" />
+      <dependency id="libxgboost-3.2.0-linux-x64" version="1.0.0" />
+      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.0" />
+      <dependency id="libxgboost-3.2.0-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>
 </package>

--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -8,7 +8,7 @@
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-linux-x64" version="1.0.0" />
-      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.1" />
+      <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.2" />
       <dependency id="libxgboost-3.2.0-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>

--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -9,6 +9,7 @@
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-linux-x64" version="1.0.0" />
       <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.2" />
+      <dependency id="libxgboost-3.2.0-osx-arm64" version="1.0.2" />
       <dependency id="libxgboost-3.2.0-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>

--- a/pkg/XGBoostSharp-cpu.nuspec
+++ b/pkg/XGBoostSharp-cpu.nuspec
@@ -9,7 +9,6 @@
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-linux-x64" version="1.0.0" />
       <dependency id="libxgboost-3.2.0-osx-x64" version="1.0.2" />
-      <dependency id="libxgboost-3.2.0-osx-arm64" version="1.0.2" />
       <dependency id="libxgboost-3.2.0-win-x64" version="1.0.0" />
     </dependencies>
   </metadata>

--- a/pkg/libxgboost-osx-arm64.targets
+++ b/pkg/libxgboost-osx-arm64.targets
@@ -3,7 +3,7 @@
   <!-- Patch libxgboost.dylib to find libomp.dylib in the same directory via @loader_path,
        overriding the Homebrew path (/usr/local/opt/libomp/lib) baked in by the XGBoost
        Python wheel build. IgnoreExitCode: install_name_tool returns 1 if the rpath already exists. -->
-  <Target Name="PatchLibxgboostRpath" AfterTargets="Build"
+  <Target Name="PatchLibxgboostRpathOsxArm64" AfterTargets="Build"
           Condition="'$(OS)' != 'Windows_NT' AND Exists('$(OutDir)runtimes/osx-arm64/native/libxgboost.dylib')">
     <Exec Command="install_name_tool -add_rpath @loader_path &quot;$(OutDir)runtimes/osx-arm64/native/libxgboost.dylib&quot;"
           IgnoreExitCode="true" />

--- a/pkg/libxgboost-osx-x64.targets
+++ b/pkg/libxgboost-osx-x64.targets
@@ -3,7 +3,7 @@
   <!-- Patch libxgboost.dylib to find libomp.dylib in the same directory via @loader_path,
        overriding the Homebrew path (/usr/local/opt/libomp/lib) baked in by the XGBoost
        Python wheel build. IgnoreExitCode: install_name_tool returns 1 if the rpath already exists. -->
-  <Target Name="PatchLibxgboostRpath" AfterTargets="Build"
+  <Target Name="PatchLibxgboostRpathOsxX64" AfterTargets="Build"
           Condition="'$(OS)' != 'Windows_NT' AND Exists('$(OutDir)runtimes/osx-x64/native/libxgboost.dylib')">
     <Exec Command="install_name_tool -add_rpath @loader_path &quot;$(OutDir)runtimes/osx-x64/native/libxgboost.dylib&quot;"
           IgnoreExitCode="true" />

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="libxgboost-3.2.0-linux-x64" Version="1.0.0" />
-    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.0" />
+    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.1" />
     <PackageReference Include="libxgboost-3.2.0-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -6,7 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="libxgboost-3.2.0-linux-x64" Version="1.0.0" />
-    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.2" />
+    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.3" />
+    <PackageReference Include="libxgboost-3.2.0-osx-arm64" Version="1.0.3" />
     <PackageReference Include="libxgboost-3.2.0-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="libxgboost-3.2.0-linux-x64" Version="1.0.0" />
     <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.2" />
-    <PackageReference Include="libxgboost-3.2.0-osx-arm64" Version="1.0.2" />
     <PackageReference Include="libxgboost-3.2.0-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="libxgboost-3.2.0-linux-x64" Version="1.0.0" />
     <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.2" />
+    <PackageReference Include="libxgboost-3.2.0-osx-arm64" Version="1.0.2" />
     <PackageReference Include="libxgboost-3.2.0-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="libxgboost-2.0.3-linux-x64" Version="1.0.3" />
-    <PackageReference Include="libxgboost-2.0.3-osx-x64" Version="1.0.1" />
-    <PackageReference Include="libxgboost-2.0.3-win-x64" Version="1.0.0" />
+    <PackageReference Include="libxgboost-3.2.0-linux-x64" Version="1.0.0" />
+    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.0" />
+    <PackageReference Include="libxgboost-3.2.0-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>
 

--- a/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
+++ b/src/XGBoostSharp.Tests/XGBoostSharp.Test.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="libxgboost-3.2.0-linux-x64" Version="1.0.0" />
-    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.1" />
+    <PackageReference Include="libxgboost-3.2.0-osx-x64" Version="1.0.2" />
     <PackageReference Include="libxgboost-3.2.0-win-x64" Version="1.0.0" />
     <PackageReference Include="MSTest" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds the following:
 - Bump native packages to target xgboost 3.2.0: https://xgboost.readthedocs.io/en/latest/changes/v3.2.0.html
 - Add osx-arm64 to XGBoostSharp-cpu.nuspec.
 - Update global.json to use latest patch and to not use preview version.
 - Fix libxgboost-osx-x64/arm64.targets to use unique names (avoid conflict when both packages referenced).
 

The new packages should also fix the issues reported in https://github.com/mdabros/XGBoostSharp/issues/68. But this needs further testing.