### PR TITLE
Add XGBoostSharp-cuda-windows.nuspec

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -90,6 +90,9 @@ jobs:
     - name: Pack XGBoostSharp-cpu
       if: ${{ github.event.inputs.version != ''  && github.actor == 'mdabros'}}
       run: nuget pack pkg/XGBoostSharp-cpu.nuspec -Version ${{ github.event.inputs.version }} -OutputDirectory ${{ env.NuGetDirectory }}
+    - name: Pack XGBoostSharp-cuda-windows
+      if: ${{ github.event.inputs.version != ''  && github.actor == 'mdabros'}}
+      run: nuget pack pkg/XGBoostSharp-cuda-windows.nuspec -Version ${{ github.event.inputs.version }} -OutputDirectory ${{ env.NuGetDirectory }}
     - uses: actions/upload-artifact@v6
       with:
         name: nuget
@@ -142,6 +145,15 @@ jobs:
         asset_path: ${{ env.NuGetDirectory }}/XGBoostSharp-cpu.${{ github.event.inputs.version }}.nupkg
         asset_name: XGBoostSharp-cpu.${{ github.event.inputs.version }}.nupkg
         asset_content_type: application/zip
+    - name: Upload XGBoostSharp-cuda-windows package
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACTION_GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ${{ env.NuGetDirectory }}/XGBoostSharp-cuda-windows.${{ github.event.inputs.version }}.nupkg
+        asset_name: XGBoostSharp-cuda-windows.${{ github.event.inputs.version }}.nupkg
+        asset_content_type: application/zip
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -150,3 +162,5 @@ jobs:
       run: dotnet nuget push ${{ env.NuGetDirectory }}/XGBoostSharp.${{ github.event.inputs.version }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Push XGBoostSharp-cpu package
       run: dotnet nuget push ${{ env.NuGetDirectory }}/XGBoostSharp-cpu.${{ github.event.inputs.version }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+    - name: Push XGBoostSharp-cuda-windows package
+      run: dotnet nuget push ${{ env.NuGetDirectory }}/XGBoostSharp-cuda-windows.${{ github.event.inputs.version }}.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
      packages for cpu for win-x64, linux-x64, osx-x64, and osx-arm64.
    - https://www.nuget.org/packages/XGBoostSharp-cuda-windows: This comes with native
      packages for win-x64 and packages for CUDA 12.8 on Windows.
-
 2. If using the XGBoostSharp package the native packages can be installed
    separately from nuget.org.
    - x64 packages:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ var loadedRegressor = XGBRegressor.LoadFromFile(modelFileName);
      reference to one of the native packages (see below).
    - https://www.nuget.org/packages/XGBoostSharp-cpu: This comes with native
      packages for cpu for win-x64, linux-x64, osx-x64, and osx-arm64.
+   - https://www.nuget.org/packages/XGBoostSharp-cuda-windows: This comes with native
+     packages for win-x64 and packages for CUDA 12.8 on Windows.
+
 2. If using the XGBoostSharp package the native packages can be installed
    separately from nuget.org.
    - x64 packages:

--- a/XGBoostSharp.slnx
+++ b/XGBoostSharp.slnx
@@ -12,6 +12,7 @@
     <File Path="pkg/libxgboost-osx-x64.targets" />
     <File Path="pkg/libxgboost-win-x64.nuspec" />
     <File Path="pkg/README-NATIVE.md" />
+    <File Path="pkg/XGBoostSharp-cuda-windows.nuspec" />
     <File Path="pkg\XGBoostSharp-cpu.nuspec" />
   </Folder>
   <Folder Name="/root/">

--- a/pkg/XGBoostSharp-cuda-windows.nuspec
+++ b/pkg/XGBoostSharp-cuda-windows.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>XGBoostSharp-cuda-windows</id>
+    <version>$version$</version>
+    <authors>mdabros</authors>
+    <description>XGBoostSharp for CUDA on Windows. Includes the CUDA-enabled XGBoost native library and required CUDA 12 runtime dependencies.</description>
+    <dependencies>
+      <dependency id="XGBoostSharp" version="$version$" />
+      <dependency id="libxgboost-3.2.0-win-x64" version="$version$" />
+      <!-- CUDA 12 runtime dependencies via NtvLibs (https://www.nuget.org/profiles/nietras) -->
+      <!-- Meta-package: includes cudart64_12, cublas64_12, cublasLt64_12, cufft64_11, nvrtc64_120_0 -->
+      <dependency id="NtvLibs.cuda12.cublas.runtime.win-x64" version="12.8.1" />
+      <!-- cuSPARSE: required for sparse matrix operations in XGBoost GPU tree methods -->
+      <dependency id="NtvLibs.cuda12.cusparse64_12.runtime.win-x64" version="12.8.1" />
+      <!-- cuDNN: required for GPU histogram and neural network boosters -->
+      <dependency id="NtvLibs.cuDNN.cuda12.runtime.win-x64" version="9.8.0.87" />
+    </dependencies>
+  </metadata>
+</package>

--- a/pkg/XGBoostSharp-cuda-windows.nuspec
+++ b/pkg/XGBoostSharp-cuda-windows.nuspec
@@ -4,7 +4,7 @@
     <id>XGBoostSharp-cuda-windows</id>
     <version>$version$</version>
     <authors>mdabros</authors>
-    <description>XGBoostSharp for CUDA on Windows. Includes the CUDA-enabled XGBoost native library and required CUDA 12 runtime dependencies.</description>
+    <description>XGBoostSharp for CUDA 12.8 on Windows.</description>
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-win-x64" version="$version$" />

--- a/pkg/XGBoostSharp-cuda-windows.nuspec
+++ b/pkg/XGBoostSharp-cuda-windows.nuspec
@@ -8,7 +8,6 @@
     <dependencies>
       <dependency id="XGBoostSharp" version="$version$" />
       <dependency id="libxgboost-3.2.0-win-x64" version="$version$" />
-      <!-- CUDA 12 runtime dependencies via NtvLibs (https://www.nuget.org/profiles/nietras) -->
       <!-- Meta-package: includes cudart64_12, cublas64_12, cublasLt64_12, cufft64_11, nvrtc64_120_0 -->
       <dependency id="NtvLibs.cuda12.cublas.runtime.win-x64" version="12.8.1" />
       <!-- cuSPARSE: required for sparse matrix operations in XGBoost GPU tree methods -->


### PR DESCRIPTION
This PR adds the following:
 - Add XGBoostSharp-cuda-windows.nuspec for CUDA support on windows.